### PR TITLE
Increase logs

### DIFF
--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -44,7 +44,10 @@ RUN pecl install xdebug \
 
 # PHP-FPM: Configuration
 RUN sed -i "s/max_execution_time = 30/max_execution_time = 120/" /etc/php/7.3/fpm/php.ini
-RUN sed -i "s/pm.max_children = 5/pm.max_children = 20/" /etc/php/7.3/fpm/pool.d/www.conf
+RUN sed -i "s/pm.max_children = 5/pm.max_children = 20/" /etc/php/7.3/fpm/pool.d/www.conf \
+    && sed -i "s/;php_admin_value[error_log] = .*/php_admin_value[error_log] = \/var\/log\/php7.3-fpm.\$pool.error.log/" /etc/php/7.3/fpm/pool.d/www.conf \
+    && sed -i "s/;access\.log = .*/access.log = \/var\/log\/php7.3-fpm.\$pool.access.log/" /etc/php/7.3/fpm/pool.d/www.conf \
+    && sed -i "s/;access\./access./" /etc/php/7.3/fpm/pool.d/www.conf
 # PHP-FPM: UDS Directory & Log Creation
 RUN mkdir /run/php && touch /var/log/php7.3-fpm.log
 # PHP-FPM: Redis as session handler

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -92,5 +92,7 @@ CMD service cron restart && /usr/sbin/apache2ctl restart && /etc/init.d/php7.3-f
         -F /var/log/apache2/error.log \
         -F /var/log/apache2/other_vhosts_access.log \
         -F /var/log/php7.3-fpm.log \
+        -F /var/log/php7.3-fpm.www.error.log \
+        -F /var/log/php7.3-fpm.www.access.log \
         -F /var/www/ez/var/logs/dev.log \
     ;

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -52,6 +52,10 @@ RUN echo "\n; Redis as session handler\nphp_value[session.save_handler] = redis\
 # Apache: FastCGI Module & PHP-FPM Configuration
 RUN a2enmod proxy_fcgi && a2enconf php7.3-fpm
 
+# Apache: Logs Conf
+COPY logs.conf /etc/apache2/conf-available/
+RUN a2enconf logs
+
 # Apache: Virtual Host Modules
 RUN a2enmod rewrite setenvif
 # Apache: Global ServerName (avoid AH00558)

--- a/docker/apache/logs.conf
+++ b/docker/apache/logs.conf
@@ -1,0 +1,6 @@
+<IfModule log_config_module>
+    # https://httpd.apache.org/docs/2.4/fr/mod/mod_log_config.html
+    LogFormat "%v:%p %h %l %u %t %Dμs \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+    LogFormat "%h %l %u %t %Dμs \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t %Dμs \"%r\" %>s %O" common
+</IfModule>


### PR DESCRIPTION
* Apache: Add `%Dµs` (time spent) to original LogFormat (/etc/apache2/apache2.conf)
* PHP-FPM: Enable access log (to have CPU usage)
* PHP: Enable error log

Taken from release/v3.0.0 aab5a3530723e46acdc55d79925356c235866523

:warning: May consume resources