### PR TITLE
Custom tags migration from eZ Publish Platform 5.4

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -64,6 +64,8 @@ class AppKernel extends Kernel
             new EzSystems\FlexWorkflowBundle\EzSystemsFlexWorkflowBundle(),
             new EzSystems\EzPlatformEnterpriseEditionInstallerBundle\EzPlatformEnterpriseEditionInstallerBundle(),
             new EzSystems\EzPlatformWorkflowBundle\EzPlatformWorkflowBundle(),
+            // Addition
+            new EzSystems\EzPlatformXmlTextFieldTypeBundle\EzSystemsEzPlatformXmlTextFieldTypeBundle(),
             // Application
             new AppBundle\AppBundle(),
         ];

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: fields.yml }
+
 ezpublish:
     # HttpCache settings, By default 'local' (Symfony HttpCache Proxy), by setting it to 'http' you can point it to Varnish
     # You may also set it to 'fastly' if you want to use the fastly CDN

--- a/app/config/fields.yml
+++ b/app/config/fields.yml
@@ -1,0 +1,29 @@
+ezpublish:
+    system:
+        default:
+            field_templates:
+                # view for `ezsrrating` from ezstarrating extension
+                - { template: '@ezdesign/fields/content_fields.html.twig', priority: 1 }
+            fieldtypes:
+                ezrichtext:
+                    custom_tags:
+                        # ezpublish_legacy/settings/content.ini / [CustomTagSettings] / AvailableCustomTags
+                        - factbox
+                        # <custom name="factbox" custom:title="[…]">[…]</custom> → <eztemplate name="factbox"><ezcontent>[…]</ezcontent><ezconfig><ezvalue key="title">[…]</ezvalue></ezconfig></eztemplate>
+                        # Already handled custom tags (which are not listed as Inline custom tags by ezxmltext:convert-to-richtext) :
+                        # - quote # <custom name="quote"> → <blockquote>
+                        # - strike #  <custom name="strike"> → <emphasis role="strikedthrough">
+                        # - sub # <custom name="sub"> → <subscript>
+                        # - sup # <custom name="sup"> → <superscript>
+
+ezrichtext:
+    custom_tags:
+        factbox:
+            #template: '@ezdesign/fields/richtext/factbox.html.twig'
+            template: 'AppBundle:themes/standard/fields/richtext:factbox.html.twig'
+            icon: '/bundles/ezplatformadminui/img/ez-icons.svg#warning'
+            attributes:
+                title:
+                    type: string
+                    required: true
+                    default_value: ''

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "ezsystems/ezplatform-standard-design": "~0.2.2",
         "ezsystems/ezplatform-user": "~1.0.7",
         "ezsystems/ezplatform-workflow": "~1.1.10",
+        "ezsystems/ezplatform-xmltext-fieldtype": "v1.*",
         "ezsystems/ezpublish-kernel": "~7.5.13",
         "ezsystems/flex-workflow": "~3.2.6",
         "ezsystems/repository-forms": "~2.5.8",
@@ -127,6 +128,9 @@
         ]
     },
     "config": {
+        "platform": {
+            "php": "7.3.19"
+        },
         "bin-dir": "bin",
         "sort-packages": true,
         "preferred-install": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c71cf092a6da2692e25f3ef02302f573",
+    "content-hash": "f0d23e6da88d014a78b630262b316466",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -312,6 +312,20 @@
                 "php",
                 "redis",
                 "xcache"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-07T18:54:01+00:00"
         },
@@ -728,6 +742,7 @@
                 "cache",
                 "caching"
             ],
+            "abandoned": true,
             "time": "2019-11-29T11:22:01+00:00"
         },
         {
@@ -803,6 +818,20 @@
                 "event manager",
                 "event system",
                 "events"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-29T18:28:51+00:00"
         },
@@ -1350,8 +1379,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/date-based-publisher/ezsystems-date-based-publisher-60fb86bc220ada0f118fa1c1be0a89f13b76b3ca-zip-ad8b4e.zip",
-                "reference": "60fb86bc220ada0f118fa1c1be0a89f13b76b3ca",
-                "shasum": null
+                "reference": "60fb86bc220ada0f118fa1c1be0a89f13b76b3ca"
             },
             "require": {
                 "ext-pdo": "*",
@@ -1850,8 +1878,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/ezplatform-form-builder/ezsystems-ezplatform-form-builder-8d72309d0de35151c4862c686e92d4696a768620-zip-1507b9.zip",
-                "reference": "8d72309d0de35151c4862c686e92d4696a768620",
-                "shasum": null
+                "reference": "8d72309d0de35151c4862c686e92d4696a768620"
             },
             "require": {
                 "ezsystems/ezplatform-admin-ui": "^1.5",
@@ -2019,8 +2046,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/ezplatform-http-cache-fastly/ezsystems-ezplatform-http-cache-fastly-04dd380ab1c729baa5dfa0b0277bf0092274c4aa-zip-ecc3de.zip",
-                "reference": "04dd380ab1c729baa5dfa0b0277bf0092274c4aa",
-                "shasum": null
+                "reference": "04dd380ab1c729baa5dfa0b0277bf0092274c4aa"
             },
             "require": {
                 "ezsystems/ezplatform-http-cache": "~0.5 || ^1.0",
@@ -2125,8 +2151,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/ezplatform-page-builder/ezsystems-ezplatform-page-builder-fcd2cf21471b3f0950a3a6439133e30eb2a65149-zip-2ee497.zip",
-                "reference": "fcd2cf21471b3f0950a3a6439133e30eb2a65149",
-                "shasum": null
+                "reference": "fcd2cf21471b3f0950a3a6439133e30eb2a65149"
             },
             "require": {
                 "ext-intl": "*",
@@ -2184,8 +2209,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/ezplatform-page-fieldtype/ezsystems-ezplatform-page-fieldtype-81024aada2e64dab478100062ad0af8947a3e1d9-zip-302952.zip",
-                "reference": "81024aada2e64dab478100062ad0af8947a3e1d9",
-                "shasum": null
+                "reference": "81024aada2e64dab478100062ad0af8947a3e1d9"
             },
             "require": {
                 "doctrine/dbal": "^2.7",
@@ -2447,8 +2471,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/ezplatform-workflow/ezsystems-ezplatform-workflow-0fb5cf5df029ebc0503a8536a00a07ce6d7c47f1-zip-504ed7.zip",
-                "reference": "0fb5cf5df029ebc0503a8536a00a07ce6d7c47f1",
-                "shasum": null
+                "reference": "0fb5cf5df029ebc0503a8536a00a07ce6d7c47f1"
             },
             "require": {
                 "ezsystems/ezplatform-admin-ui": "^1.5",
@@ -2504,6 +2527,61 @@
             "time": "2020-09-15T11:17:10+00:00"
         },
         {
+            "name": "ezsystems/ezplatform-xmltext-fieldtype",
+            "version": "v1.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezsystems/ezplatform-xmltext-fieldtype.git",
+                "reference": "2dfaa7f34a75673cc15f98a98dbf6ad687dcd3ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezsystems/ezplatform-xmltext-fieldtype/zipball/2dfaa7f34a75673cc15f98a98dbf6ad687dcd3ee",
+                "reference": "2dfaa7f34a75673cc15f98a98dbf6ad687dcd3ee",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xsl": "*",
+                "ezsystems/ezplatform-richtext": "^1.1",
+                "ezsystems/ezpublish-kernel": "^7.5.1@dev",
+                "ezsystems/repository-forms": "^2.5.0",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "ezsystems/ezplatform-solr-search-engine": "^1.5.7",
+                "friendsofphp/php-cs-fixer": "v2.14.2",
+                "matthiasnoback/symfony-dependency-injection-test": "^2.3.1",
+                "phpunit/phpunit": "^6.5.9"
+            },
+            "type": "ezplatform-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "EzSystems\\EzPlatformXmlTextFieldTypeBundle\\": "bundle",
+                    "eZ\\Publish\\Core\\FieldType\\XmlText\\": "lib/FieldType/XmlText",
+                    "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\": "lib/Persistence/Legacy/Content/FieldValue/Converter",
+                    "eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessor\\": "lib/REST/Common/FieldTypeProcessor"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "eZ dev-team & eZ Community",
+                    "homepage": "https://github.com/ezsystems/ezplatform-xmltext-fieldtype/contributors"
+                }
+            ],
+            "description": "XmlText field type implementation for eZ Platform",
+            "time": "2020-04-10T08:53:26+00:00"
+        },
+        {
             "name": "ezsystems/ezpublish-kernel",
             "version": "v7.5.13",
             "source": {
@@ -2514,8 +2592,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/ezpublish-kernel/ezsystems-ezpublish-kernel-14b3c668add4528411c29253af5e0b2fa1cff411-zip-a326da.zip",
-                "reference": "14b3c668add4528411c29253af5e0b2fa1cff411",
-                "shasum": null
+                "reference": "14b3c668add4528411c29253af5e0b2fa1cff411"
             },
             "require": {
                 "composer/package-versions-deprecated": "^1.11",
@@ -2629,8 +2706,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://updates.ez.no/ttl/dist/ezsystems/flex-workflow/ezsystems-flex-workflow-0bed82bf72d5b58c06cf250298873969f21bf7bd-zip-a35e1f.zip",
-                "reference": "0bed82bf72d5b58c06cf250298873969f21bf7bd",
-                "shasum": null
+                "reference": "0bed82bf72d5b58c06cf250298873969f21bf7bd"
             },
             "require": {
                 "ezsystems/date-based-publisher": "^3.2",
@@ -4112,6 +4188,16 @@
                 "JWS",
                 "jwt"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
             "time": "2020-08-20T13:22:28+00:00"
         },
         {
@@ -4291,6 +4377,12 @@
                 "jwt",
                 "rest",
                 "symfony"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/chalasr",
+                    "type": "github"
+                }
             ],
             "time": "2020-10-27T17:30:41+00:00"
         },
@@ -6489,6 +6581,20 @@
                 "log",
                 "logging"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-10-06T15:12:11+00:00"
         },
         {
@@ -6736,6 +6842,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-10-23T14:02:19+00:00"
         },
         {
@@ -6806,6 +6926,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-10-23T14:02:19+00:00"
         },
         {
@@ -6873,6 +7007,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-10-23T14:02:19+00:00"
         },
         {
@@ -6935,6 +7083,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-10-23T14:02:19+00:00"
         },
@@ -7096,6 +7258,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-10-23T14:02:19+00:00"
         },
@@ -7421,6 +7597,20 @@
                 }
             ],
             "description": "Encourages sending ⭐ and 💵 to fellow PHP package maintainers (not limited to Symfony components)!",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-10-14T17:47:37+00:00"
         },
         {
@@ -7474,6 +7664,20 @@
                 }
             ],
             "description": "Integration with your Symfony app & Webpack Encore!",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-10-28T17:07:25+00:00"
         },
         {
@@ -7647,6 +7851,12 @@
                 "api",
                 "graphql"
             ],
+            "funding": [
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
             "time": "2020-07-02T05:49:25+00:00"
         },
         {
@@ -7654,12 +7864,12 @@
             "version": "v1.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle.git",
+                "url": "https://github.com/sampart/WhiteOctoberPagerfantaBundle.git",
                 "reference": "6df560869b5e09a3acf920890ab40598998b30ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/whiteoctober/WhiteOctoberPagerfantaBundle/zipball/6df560869b5e09a3acf920890ab40598998b30ae",
+                "url": "https://api.github.com/repos/sampart/WhiteOctoberPagerfantaBundle/zipball/6df560869b5e09a3acf920890ab40598998b30ae",
                 "reference": "6df560869b5e09a3acf920890ab40598998b30ae",
                 "shasum": ""
             },
@@ -9076,6 +9286,71 @@
             "time": "2020-11-06T11:51:38+00:00"
         },
         {
+            "name": "ezsystems/diff",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezsystems/diff.git",
+                "reference": "857eed173c181b577c83054bfe182a2843991b2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezsystems/diff/zipball/857eed173c181b577c83054bfe182a2843991b2d",
+                "reference": "857eed173c181b577c83054bfe182a2843991b2d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "replace": {
+                "sebastian/diff": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-03-16T20:00:19+00:00"
+        },
+        {
             "name": "fabpot/goutte",
             "version": "v3.2.3",
             "source": {
@@ -9531,6 +9806,12 @@
                 "duplicate",
                 "object",
                 "object graph"
+            ],
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-29T13:22:24+00:00"
         },
@@ -10512,58 +10793,6 @@
             "time": "2018-02-01T13:46:46+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff"
-            ],
-            "time": "2017-08-03T08:09:46+00:00"
-        },
-        {
             "name": "sebastian/environment",
             "version": "3.1.0",
             "source": {
@@ -11176,5 +11405,9 @@
     "platform": {
         "php": "^7.1.3"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3.19"
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/src/AppBundle/Resources/views/themes/standard/fields/content_fields.html.twig
+++ b/src/AppBundle/Resources/views/themes/standard/fields/content_fields.html.twig
@@ -1,0 +1,11 @@
+{% extends 'EzPublishCoreBundle::content_fields.html.twig' %}
+
+{#
+Field type definition: https://github.com/ezsystems/ezpublish-kernel/blob/v7.5.13/eZ/Publish/Core/settings/fieldtypes.yml#L17
+Its settings template: https://github.com/ezsystems/ezpublish-kernel/blob/v7.5.13/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig#L302
+But no view in https://github.com/ezsystems/ezpublish-kernel/blob/v7.5.13/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+#}
+
+{% block ezsrrating_field %}
+{#    {{ dump(field) }}#}
+{% endblock %}

--- a/src/AppBundle/Resources/views/themes/standard/fields/richtext/factbox.html.twig
+++ b/src/AppBundle/Resources/views/themes/standard/fields/richtext/factbox.html.twig
@@ -1,0 +1,4 @@
+{# Adapted from ezpublish_legacy/design/standard/templates/content/datatype/view/ezxmltags/factbox.tpl #}
+<div class="factbox" style="background-color: #eee;"{# TODO: Move style to a file #}>
+    {{ content|raw }}
+</div>


### PR DESCRIPTION
Everything to migrate an eZ Publish 5.4 clean-install Database to eZ Platform 2.5

- [x] XMLText to Rich Text
- [ ] eZ Flow (to Landing Page) to Page
