### PR TITLE
Varnish: better config

### DIFF
--- a/docker-compose.bash
+++ b/docker-compose.bash
@@ -199,7 +199,7 @@ docker-compose up --build --detach $enabled_containers;
 rm -rf ./docker/solr/conf;
 
 # Varnish: Clean-up build folder
-#rm -f ./docker/varnish/default.vcl;
+rm -f ./docker/varnish/default.vcl;
 
 # Apache: Add write rights to var folders
 docker-compose exec apache chown www-data -R var/ public/var/;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,13 @@ version: '3'
 services:
 
   varnish:
-    #build: ./docker/varnish
-    image: ghcr.io/emgag/varnish:6.0.10
+    build: ./docker/varnish
     depends_on:
       - apache
     ports:
       - 8080:80
     environment:
-      #- VARNISH_LISTEN=8080
       - VARNISH_STORAGE=malloc,256m
-    volumes:
-      - ./docker/varnish:/etc/varnish
 
   apache:
     build: ./docker/apache

--- a/docker/varnish/Dockerfile
+++ b/docker/varnish/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/emgag/varnish:6.0.10
+
+COPY default.vcl /etc/varnish/default.vcl
+
+WORKDIR /etc/varnish


### PR DESCRIPTION
To not have default.vcl as untracked file, let's COPY it instead of mounting it as a volume.

TODO: Use parameters.vcl by fixing the following:
```
ezplatform-ee-docker-varnish-1  | Error:
ezplatform-ee-docker-varnish-1  | Message from VCC-compiler:
ezplatform-ee-docker-varnish-1  | Cannot read file 'parameters.vcl' (No such file or directory)
ezplatform-ee-docker-varnish-1  | ('/etc/varnish/default.vcl' Line 13 Pos 9)
ezplatform-ee-docker-varnish-1  | include "parameters.vcl";
ezplatform-ee-docker-varnish-1  | --------################-
ezplatform-ee-docker-varnish-1  | 
ezplatform-ee-docker-varnish-1  | Running VCC-compiler failed, exited with 2
ezplatform-ee-docker-varnish-1  | VCL compilation failed
```