### PR TITLE
Single Container

### DIFF
--- a/docker/single/Dockerfile
+++ b/docker/single/Dockerfile
@@ -1,0 +1,59 @@
+FROM debian:10
+
+LABEL maintainer="adrien.dupuis@ibexa.co"
+LABEL description="Ibexa DXP 3.3"
+
+# Usage:
+# docker build . -f docker/single/Dockerfile -t ibexa-single && docker run --name ibexa-single --detach --publish 8055:8080 ibexa-single;
+# docker exec -ti ibexa-single bash;
+# docker rm -f ibexa-single;
+
+#ARG installation-key
+#ARG token-password
+
+RUN apt-get -qq update \
+  && apt-get -qq install -y \
+    curl \
+    git \
+    zip unzip \
+    mariadb-server \
+    php-cli \
+    #php-fpm \
+    php-mysql \
+    php-xml \
+    php-mbstring \
+    php-json \
+    php-intl \
+    php-curl \
+    #php-pear \
+    php-gd \
+    #php-imagick \
+;
+
+RUN service mysql start
+
+# Composer 2
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+# NodeJS 12
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && apt-get install -y nodejs
+# Yarn
+RUN npm install -g yarn
+
+#RUN composer config --global http-basic.updates.ibexa.co $installation-key $token-password
+COPY auth.json /root/.composer/auth.json
+
+RUN mkdir /var/www
+WORKDIR /var/www
+
+RUN composer create-project ibexa/content-skeleton:^3.3 .
+
+RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
+
+RUN service mysql start \
+  && php bin/console ibexa:install \
+  && php bin/console ibexa:graphql:generate-schema \
+  && composer run post-install-cmd
+
+EXPOSE 8080
+CMD service mysql start && php -S 0.0.0.0:8080 -t public

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -5,7 +5,7 @@ LABEL description="eZ Platform 2.5"
 
 # Usage:
 # docker build . -f docker/single/Dockerfile-v2 -t ibexa-dxp:v2 && docker run --name ibexa-dxp-v2 --detach --publish 8002:8080 ibexa-dxp:v2;
-# docker build . -f docker/single/Dockerfile-v2 --build-arg flavor=commerce --build-arg version=2.5.19 -t ibexa-dxp:v2 && docker run --name ibexa-dxp-v2 --detach --publish 8002:8080 ibexa-dxp:v2;
+# docker build . -f docker/single/Dockerfile-v2 --build-arg flavor=ezcommerce --build-arg version=2.5.20 -t ibexa-dxp:v2 && docker run --name ibexa-dxp-v2 --detach --publish 8002:8080 ibexa-dxp:v2;
 # docker exec -ti ibexa-dxp-v2 bash;
 # docker exec -ti ibexa-dxp-v2 mysql ibexa;
 # docker rm -f ibexa-dxp-v2;
@@ -13,9 +13,9 @@ LABEL description="eZ Platform 2.5"
 #ARG installation-key
 #ARG token-password
 ARG flavor=ezplatform-ee
-ARG version=2.5.30
+ARG version=2.5.31
 #ARG flavor=ezcommerce
-#ARG version=2.5.19
+#ARG version=2.5.20
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -35,12 +35,13 @@ RUN apt-get -qq update \
     #php-pear \
     php-gd \
     #php-imagick \
+    # Composer 1
+    composer \
+    build-essential \
 ;
 
 RUN service mysql start
 
-# Composer 2
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 # https://doc.ibexa.co/en/3.3/getting_started/requirements/#asset-manager
 # NodeJS 10
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
@@ -64,4 +65,5 @@ RUN service mysql start \
   && composer ezplatform-install
 
 EXPOSE 8080
-CMD service mysql start && php -S 0.0.0.0:8080 -t public
+RUN cp web/app_dev.php web/index.php
+CMD service mysql start && php -S 0.0.0.0:8080 -t web

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -17,6 +17,8 @@ ARG version=2.5.30
 #ARG flavor=ezcommerce
 #ARG version=2.5.19
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get -qq update \
   && apt-get -qq install -y \
     curl \

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -42,7 +42,7 @@ RUN apt-get -qq update \
 
 RUN service mysql start
 
-# https://doc.ibexa.co/en/3.3/getting_started/requirements/#asset-manager
+# https://doc.ibexa.co/en/2.5/getting_started/requirements/#asset-manager
 # NodeJS 10
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get install -y nodejs
@@ -65,5 +65,5 @@ RUN service mysql start \
   && composer ezplatform-install
 
 EXPOSE 8080
-RUN cp web/app_dev.php web/index.php
+RUN ln -s app_dev.php web/index.php
 CMD service mysql start && php -S 0.0.0.0:8080 -t web

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -40,8 +40,6 @@ RUN apt-get -qq update \
     build-essential \
 ;
 
-RUN service mysql start
-
 # https://doc.ibexa.co/en/2.5/getting_started/requirements/#asset-manager
 # NodeJS 10
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
@@ -66,4 +64,4 @@ RUN service mysql start \
 
 EXPOSE 8080
 RUN ln -s app_dev.php web/index.php
-CMD service mysql start && php -S 0.0.0.0:8080 -t web
+CMD service mysql restart && php -S 0.0.0.0:8080 -t web

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -1,19 +1,21 @@
 FROM debian:10
 
 LABEL maintainer="adrien.dupuis@ibexa.co"
-LABEL description="Ibexa DXP 3.3"
+LABEL description="eZ Platform 2.5"
 
 # Usage:
-# docker build . -f docker/single/Dockerfile-v3 -t ibexa-dxp:v3 && docker run --name ibexa-dxp-v3 --detach --publish 8003:8080 ibexa-dxp:v3;
-# docker build . -f docker/single/Dockerfile-v3 --build-arg flavor=commerce -t ibexa-dxp:v3-commerce && docker run --name ibexa-dxp-v3-commerce --detach --publish 8003:8080 ibexa-dxp:v3-commerce;
-# docker exec -ti ibexa-dxp-v3 bash;
-# docker exec -ti ibexa-dxp-v3 mysql ibexa;
-# docker rm -f ibexa-dxp-v3;
+# docker build . -f docker/single/Dockerfile-v2 -t ibexa-dxp:v2 && docker run --name ibexa-dxp-v2 --detach --publish 8002:8080 ibexa-dxp:v2;
+# docker build . -f docker/single/Dockerfile-v2 --build-arg flavor=commerce -t ibexa-dxp:v2-commerce && docker run --name ibexa-dxp-v2-commerce --detach --publish 8002:8080 ibexa-dxp:v2-commerce;
+# docker exec -ti ibexa-dxp-v2 bash;
+# docker exec -ti ibexa-dxp-v2 mysql ibexa;
+# docker rm -f ibexa-dxp-v2;
 
 #ARG installation-key
 #ARG token-password
-ARG flavor=experience
-ARG version=^3.3
+ARG flavor=ezplatform-ee
+ARG version=2.5.28
+#ARG flavor=ezcommerce
+#ARG version=2.5.17
 
 RUN apt-get -qq update \
   && apt-get -qq install -y \
@@ -21,7 +23,7 @@ RUN apt-get -qq update \
     git \
     zip unzip \
     mariadb-server \
-    # https://doc.ibexa.co/en/3.3/getting_started/requirements/#php-packages
+    # https://doc.ibexa.co/en/2.5/getting_started/requirements/#php-packages
     php-cli \
     #php-fpm \
     php-mysql \
@@ -34,15 +36,14 @@ RUN apt-get -qq update \
     php-gd \
     #php-imagick \
 ;
-RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php-zip; fi;
 
 RUN service mysql start
 
 # Composer 2
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 # https://doc.ibexa.co/en/3.3/getting_started/requirements/#asset-manager
-# NodeJS 12
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+# NodeJS 10
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get install -y nodejs
 # Yarn
 RUN npm install -g yarn
@@ -53,15 +54,14 @@ COPY auth.json /root/.composer/auth.json
 RUN mkdir /var/www
 WORKDIR /var/www
 
-RUN composer create-project ibexa/$flavor-skeleton:$version .
+RUN git clone https://github.com/ezsystems/$flavor.git -b v$version .
+#RUN composer create-project --keep-vcs ezsystems/ezplatform . $version
 
 RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
 
 RUN service mysql start \
-  #&& php bin/console ibexa:install ibexa-$flavor \
-  && php bin/console ibexa:install \
-  && php bin/console ibexa:graphql:generate-schema \
-  && composer run post-install-cmd
+  && composer install \
+  && composer ezplatform-install
 
 EXPOSE 8080
 CMD service mysql start && php -S 0.0.0.0:8080 -t public

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -38,7 +38,7 @@ RUN apt-get -qq update \
     # Composer 1
     composer \
     build-essential \
-;
+  ;
 
 # https://doc.ibexa.co/en/2.5/getting_started/requirements/#asset-manager
 # NodeJS 10

--- a/docker/single/Dockerfile-v2
+++ b/docker/single/Dockerfile-v2
@@ -5,7 +5,7 @@ LABEL description="eZ Platform 2.5"
 
 # Usage:
 # docker build . -f docker/single/Dockerfile-v2 -t ibexa-dxp:v2 && docker run --name ibexa-dxp-v2 --detach --publish 8002:8080 ibexa-dxp:v2;
-# docker build . -f docker/single/Dockerfile-v2 --build-arg flavor=commerce -t ibexa-dxp:v2-commerce && docker run --name ibexa-dxp-v2-commerce --detach --publish 8002:8080 ibexa-dxp:v2-commerce;
+# docker build . -f docker/single/Dockerfile-v2 --build-arg flavor=commerce --build-arg version=2.5.19 -t ibexa-dxp:v2 && docker run --name ibexa-dxp-v2 --detach --publish 8002:8080 ibexa-dxp:v2;
 # docker exec -ti ibexa-dxp-v2 bash;
 # docker exec -ti ibexa-dxp-v2 mysql ibexa;
 # docker rm -f ibexa-dxp-v2;
@@ -13,9 +13,9 @@ LABEL description="eZ Platform 2.5"
 #ARG installation-key
 #ARG token-password
 ARG flavor=ezplatform-ee
-ARG version=2.5.28
+ARG version=2.5.30
 #ARG flavor=ezcommerce
-#ARG version=2.5.17
+#ARG version=2.5.19
 
 RUN apt-get -qq update \
   && apt-get -qq install -y \

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -33,6 +33,10 @@ RUN apt-get -qq update \
     #php-pear \
     php-gd \
     #php-imagick \
+    # Required by Yarn with Ibexa DXP 3.3.14 and below:
+    python \
+    make \
+    g++ \
 ;
 RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php-zip; fi;
 

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -5,7 +5,8 @@ LABEL description="Ibexa DXP 3.3"
 
 # Usage:
 # docker build . -f docker/single/Dockerfile-v3 -t ibexa-dxp:v3 && docker run --name ibexa-dxp-v3 --detach --publish 8003:8080 ibexa-dxp:v3;
-# docker build . -f docker/single/Dockerfile-v3 --build-arg flavor=commerce -t ibexa-dxp:v3-commerce && docker run --name ibexa-dxp-v3-commerce --detach --publish 8003:8080 ibexa-dxp:v3-commerce;
+# docker build . -f docker/single/Dockerfile-v3 --build-arg flavor=commerce -t ibexa-dxp:v3 && docker run --name ibexa-dxp-v3 --detach --publish 8003:8080 ibexa-dxp:v3;
+# docker build . -f docker/single/Dockerfile-v3 --build-arg version=3.3.14 -t ibexa-dxp:v3 && docker run --name ibexa-dxp-v3 --detach --publish 8003:8080 ibexa-dxp:v3;
 # docker exec -ti ibexa-dxp-v3 bash;
 # docker exec -ti ibexa-dxp-v3 mysql ibexa;
 # docker rm -f ibexa-dxp-v3;

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -38,7 +38,7 @@ RUN apt-get -qq update \
     python \
     make \
     g++ \
-;
+  ;
 RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php-zip; fi;
 
 # Composer 2
@@ -56,7 +56,14 @@ COPY auth.json /root/.composer/auth.json
 RUN mkdir /var/www
 WORKDIR /var/www
 
-RUN composer create-project ibexa/$flavor-skeleton:$version .
+RUN if [ 3.3.7 = $version ] || [ 3.3.6 = $version ] || [ 3.3.5 = $version ] || [ 3.3.4 = $version ] || [ 3.3.3 = $version ] || [ 3.3.2 = $version ] || [ 3.3.1 = $version ] || [ 3.3.0 = $version ]; then \
+      composer create-project ibexa/$flavor-skeleton:$version . --no-install \
+      && sed -i -E  's/(github.com\/.*)hautelook/\1goetas/' composer.lock \
+      && composer install; \
+    else \
+      composer create-project ibexa/$flavor-skeleton:$version .; \
+    fi;
+
 
 RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
 

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -41,8 +41,6 @@ RUN apt-get -qq update \
 ;
 RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php-zip; fi;
 
-RUN service mysql start
-
 # Composer 2
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 # https://doc.ibexa.co/en/3.3/getting_started/requirements/#asset-manager
@@ -69,4 +67,4 @@ RUN service mysql start \
   && composer run post-install-cmd
 
 EXPOSE 8080
-CMD service mysql start && php -S 0.0.0.0:8080 -t public
+CMD service mysql restart && php -S 0.0.0.0:8080 -t public

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -16,6 +16,8 @@ LABEL description="Ibexa DXP 3.3"
 ARG flavor=experience
 ARG version=^3.3
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get -qq update \
   && apt-get -qq install -y \
     curl \

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -4,12 +4,14 @@ LABEL maintainer="adrien.dupuis@ibexa.co"
 LABEL description="Ibexa DXP 3.3"
 
 # Usage:
-# docker build . -f docker/single/Dockerfile -t ibexa-single && docker run --name ibexa-single --detach --publish 8055:8080 ibexa-single;
-# docker exec -ti ibexa-single bash;
-# docker rm -f ibexa-single;
+# docker build . -f docker/single/Dockerfile-v3 -t ibexa-single && docker run --name ibexa-single --detach --publish 8003:8080 ibexa-single;
+# docker build . -f docker/single/Dockerfile-v3 --build-arg flavor=commerce -t ibexa-single && docker run --name ibexa-single-v3 --detach --publish 8003:8080 ibexa-single;
+# docker exec -ti ibexa-single-v3 bash;
+# docker rm -f ibexa-single-v3;
 
 #ARG installation-key
 #ARG token-password
+ARG flavor=experience
 
 RUN apt-get -qq update \
   && apt-get -qq install -y \
@@ -17,6 +19,7 @@ RUN apt-get -qq update \
     git \
     zip unzip \
     mariadb-server \
+    # https://doc.ibexa.co/en/3.3/getting_started/requirements/#php-packages
     php-cli \
     #php-fpm \
     php-mysql \
@@ -29,11 +32,13 @@ RUN apt-get -qq update \
     php-gd \
     #php-imagick \
 ;
+RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php-zip; fi;
 
 RUN service mysql start
 
 # Composer 2
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+# https://doc.ibexa.co/en/3.3/getting_started/requirements/#asset-manager
 # NodeJS 12
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
   && apt-get install -y nodejs
@@ -46,11 +51,12 @@ COPY auth.json /root/.composer/auth.json
 RUN mkdir /var/www
 WORKDIR /var/www
 
-RUN composer create-project ibexa/content-skeleton:^3.3 .
+RUN composer create-project ibexa/$flavor-skeleton:^3.3 .
 
 RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
 
 RUN service mysql start \
+  #&& php bin/console ibexa:install ibexa-$flavor \
   && php bin/console ibexa:install \
   && php bin/console ibexa:graphql:generate-schema \
   && composer run post-install-cmd

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -4,10 +4,10 @@ LABEL maintainer="adrien.dupuis@ibexa.co"
 LABEL description="Ibexa DXP 3.3"
 
 # Usage:
-# docker build . -f docker/single/Dockerfile-v3 -t ibexa-single && docker run --name ibexa-single --detach --publish 8003:8080 ibexa-single;
-# docker build . -f docker/single/Dockerfile-v3 --build-arg flavor=commerce -t ibexa-single && docker run --name ibexa-single-v3 --detach --publish 8003:8080 ibexa-single;
-# docker exec -ti ibexa-single-v3 bash;
-# docker rm -f ibexa-single-v3;
+# docker build . -f docker/single/Dockerfile-v3 -t ibexa-dxp:v3 && docker run --name ibexa-dxp-v3 --detach --publish 8003:8080 ibexa-dxp:v3;
+# docker build . -f docker/single/Dockerfile-v3 --build-arg flavor=commerce -t ibexa-dxp:v3-commerce && docker run --name ibexa-dxp-v3-commerce --detach --publish 8003:8080 ibexa-dxp:v3-commerce;
+# docker exec -ti ibexa-dxp-v3 bash;
+# docker rm -f ibexa-dxp-v3;
 
 #ARG installation-key
 #ARG token-password

--- a/docker/single/Dockerfile-v3
+++ b/docker/single/Dockerfile-v3
@@ -12,6 +12,7 @@ LABEL description="Ibexa DXP 3.3"
 #ARG installation-key
 #ARG token-password
 ARG flavor=experience
+ARG version=^3.3
 
 RUN apt-get -qq update \
   && apt-get -qq install -y \
@@ -51,7 +52,7 @@ COPY auth.json /root/.composer/auth.json
 RUN mkdir /var/www
 WORKDIR /var/www
 
-RUN composer create-project ibexa/$flavor-skeleton:^3.3 .
+RUN composer create-project ibexa/$flavor-skeleton:$version .
 
 RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
 

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -4,10 +4,10 @@ LABEL maintainer="adrien.dupuis@ibexa.co"
 LABEL description="Ibexa DXP 4.0"
 
 # Usage:
-# docker build . -f docker/single/Dockerfile-v4 -t ibexa-single && docker run --name ibexa-single --detach --publish 8004:8080 ibexa-single;
-# docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-single && docker run --name ibexa-single-v4 --detach --publish 8004:8080 ibexa-single;
-# docker exec -ti ibexa-single-v4 bash;
-# docker rm -f ibexa-single-v4;
+# docker build . -f docker/single/Dockerfile-v4 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
+# docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-dxp:v4-commerce && docker run --name ibexa-dxp-v4-commerce --detach --publish 8004:8080 ibexa-dxp:v4-commerce;
+# docker exec -ti ibexa-dxp-v4 bash;
+# docker rm -f ibexa-dxp-v4;
 
 #ARG installation-key
 #ARG token-password

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -46,8 +46,6 @@ RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php7.4-zip; fi;
 
 RUN update-alternatives --set php /usr/bin/php7.4
 
-RUN service mysql start
-
 # Composer 2
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 # https://doc.ibexa.co/en/4.0/getting_started/requirements/#asset-manager
@@ -74,4 +72,4 @@ RUN service mysql start \
   && composer run post-install-cmd
 
 EXPOSE 8080
-CMD service mysql start && php -S 0.0.0.0:8080 -t public
+CMD service mysql restart && php -S 0.0.0.0:8080 -t public

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -1,7 +1,7 @@
 FROM debian:10
 
 LABEL maintainer="adrien.dupuis@ibexa.co"
-LABEL description="Ibexa DXP 4.0"
+LABEL description="Ibexa DXP 4.x"
 
 # Usage:
 # docker build . -f docker/single/Dockerfile-v4 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -1,0 +1,74 @@
+FROM debian:10
+
+LABEL maintainer="adrien.dupuis@ibexa.co"
+LABEL description="Ibexa DXP 4.0"
+
+# Usage:
+# docker build . -f docker/single/Dockerfile-v4 -t ibexa-single && docker run --name ibexa-single --detach --publish 8004:8080 ibexa-single;
+# docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-single && docker run --name ibexa-single-v4 --detach --publish 8004:8080 ibexa-single;
+# docker exec -ti ibexa-single-v4 bash;
+# docker rm -f ibexa-single-v4;
+
+#ARG installation-key
+#ARG token-password
+ARG flavor=experience
+
+# https://doc.ibexa.co/en/4.0/getting_started/requirements/#php
+# PHP PPA Repository for PHP 7.4
+RUN apt-get -qq update \
+    && apt-get -qq install -y wget lsb-release apt-transport-https ca-certificates \
+    && wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
+    && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" >> /etc/apt/sources.list.d/php.list
+
+RUN apt-get -qq update \
+  && apt-get -qq install -y \
+    curl \
+    git \
+    zip unzip \
+    mariadb-server \
+    # https://doc.ibexa.co/en/4.0/getting_started/requirements/#php-packages
+    php7.4-cli \
+    #php7.4-fpm \
+    php7.4-mysql \
+    php7.4-xml \
+    php7.4-mbstring \
+    php7.4-json \
+    php7.4-intl \
+    php7.4-curl \
+    #php7.4-pear \
+    php7.4-gd \
+    #php7.4-imagick \
+;
+RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php7.4-zip; fi;
+
+RUN update-alternatives --set php /usr/bin/php7.4
+
+RUN service mysql start
+
+# Composer 2
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+# https://doc.ibexa.co/en/4.0/getting_started/requirements/#asset-manager
+# NodeJS 14
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+  && apt-get install -y nodejs
+# Yarn
+RUN npm install -g yarn
+
+#RUN composer config --global http-basic.updates.ibexa.co $installation-key $token-password
+COPY auth.json /root/.composer/auth.json
+
+RUN mkdir /var/www
+WORKDIR /var/www
+
+RUN composer create-project ibexa/$flavor-skeleton:^4.0 .
+
+RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
+
+RUN service mysql start \
+  #&& php bin/console ibexa:install ibexa-$flavor \
+  && php bin/console ibexa:install \
+  && php bin/console ibexa:graphql:generate-schema \
+  && composer run post-install-cmd
+
+EXPOSE 8080
+CMD service mysql start && php -S 0.0.0.0:8080 -t public

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -41,7 +41,7 @@ RUN apt-get -qq update \
     #php7.4-pear \
     php7.4-gd \
     #php7.4-imagick \
-;
+  ;
 RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php7.4-zip; fi;
 
 RUN update-alternatives --set php /usr/bin/php7.4

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -9,7 +9,7 @@ LABEL description="Ibexa DXP 4.x"
 # docker build . -f docker/single/Dockerfile-v4 --build-arg version=4.0 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
 # docker exec -ti ibexa-dxp-v4 bash;
 # docker exec -ti ibexa-dxp-v4 mysql ibexa;
-# docker rm -f ibexa-dxp-v4;
+# docker rm -f ibexa-dxp-v4; docker rmi ibexa-dxp:v4;
 
 #ARG installation-key
 #ARG token-password
@@ -25,7 +25,9 @@ RUN apt-get -qq update \
     && wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
     && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" >> /etc/apt/sources.list.d/php.list
 
-RUN if [[ $version =~ ^4\.[0-2]\. ]]; then \
+SHELL ["/bin/bash", "-c"]
+
+RUN if [[ "$version" =~ ^4\.[0-2] ]]; then \
     php_version=7.4; \
   else \
     php_version=8.1; \
@@ -61,6 +63,13 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y nodejs
 # Yarn
 RUN npm install -g yarn
+RUN if [[ "$version" =~ ^4\.0 ]]; then \
+      # Required by Yarn with Ibexa DXP 4.0:
+      apt-get -qq install -y make g++ python2.7 \
+      && echo "export PYTHON=python2.7" >> /root/.bashrc; \
+    else \
+      touch /root/.bashrc; \
+    fi;
 
 #RUN composer config --global http-basic.updates.ibexa.co $installation-key $token-password
 COPY auth.json /root/.composer/auth.json
@@ -68,7 +77,7 @@ COPY auth.json /root/.composer/auth.json
 RUN mkdir /var/www
 WORKDIR /var/www
 
-RUN composer create-project ibexa/$flavor-skeleton:$version .
+RUN composer create-project ibexa/$flavor-skeleton:$version . --no-scripts
 
 RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
 
@@ -76,6 +85,7 @@ RUN service mysql start \
   #&& php bin/console ibexa:install ibexa-$flavor \
   && php bin/console ibexa:install \
   && php bin/console ibexa:graphql:generate-schema \
+  && source /root/.bashrc \
   && composer run post-install-cmd
 
 EXPOSE 8080

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -7,6 +7,7 @@ LABEL description="Ibexa DXP 4.0"
 # docker build . -f docker/single/Dockerfile-v4 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
 # docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-dxp:v4-commerce && docker run --name ibexa-dxp-v4-commerce --detach --publish 8004:8080 ibexa-dxp:v4-commerce;
 # docker exec -ti ibexa-dxp-v4 bash;
+# docker exec -ti ibexa-dxp-v4 mysql ibexa;
 # docker rm -f ibexa-dxp-v4;
 
 #ARG installation-key

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -5,7 +5,8 @@ LABEL description="Ibexa DXP 4.0"
 
 # Usage:
 # docker build . -f docker/single/Dockerfile-v4 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
-# docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-dxp:v4-commerce && docker run --name ibexa-dxp-v4-commerce --detach --publish 8004:8080 ibexa-dxp:v4-commerce;
+# docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
+# docker build . -f docker/single/Dockerfile-v4 --build-arg version=~4.0.0 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
 # docker exec -ti ibexa-dxp-v4 bash;
 # docker exec -ti ibexa-dxp-v4 mysql ibexa;
 # docker rm -f ibexa-dxp-v4;
@@ -13,7 +14,7 @@ LABEL description="Ibexa DXP 4.0"
 #ARG installation-key
 #ARG token-password
 ARG flavor=experience
-ARG version=^4.0
+ARG version=^4.1
 
 # https://doc.ibexa.co/en/4.0/getting_started/requirements/#php
 # PHP PPA Repository for PHP 7.4

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -6,7 +6,7 @@ LABEL description="Ibexa DXP 4.x"
 # Usage:
 # docker build . -f docker/single/Dockerfile-v4 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
 # docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
-# docker build . -f docker/single/Dockerfile-v4 --build-arg version=~4.0.0 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
+# docker build . -f docker/single/Dockerfile-v4 --build-arg version=4.0 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
 # docker exec -ti ibexa-dxp-v4 bash;
 # docker exec -ti ibexa-dxp-v4 mysql ibexa;
 # docker rm -f ibexa-dxp-v4;
@@ -14,39 +14,44 @@ LABEL description="Ibexa DXP 4.x"
 #ARG installation-key
 #ARG token-password
 ARG flavor=experience
-ARG version=^4.1
+ARG version=^4.4
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # https://doc.ibexa.co/en/4.0/getting_started/requirements/#php
-# PHP PPA Repository for PHP 7.4
+# PHP PPA Repository for PHP 7.4 or 8.1
 RUN apt-get -qq update \
     && apt-get -qq install -y wget lsb-release apt-transport-https ca-certificates \
     && wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
     && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" >> /etc/apt/sources.list.d/php.list
 
-RUN apt-get -qq update \
+RUN if [[ $version =~ ^4\.[0-2]\. ]]; then \
+    php_version=7.4; \
+  else \
+    php_version=8.1; \
+  fi; \
+  apt-get -qq update \
   && apt-get -qq install -y \
     curl \
     git \
     zip unzip \
     mariadb-server \
     # https://doc.ibexa.co/en/4.0/getting_started/requirements/#php-packages
-    php7.4-cli \
-    #php7.4-fpm \
-    php7.4-mysql \
-    php7.4-xml \
-    php7.4-mbstring \
-    php7.4-json \
-    php7.4-intl \
-    php7.4-curl \
-    #php7.4-pear \
-    php7.4-gd \
-    #php7.4-imagick \
-  ;
-RUN if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php7.4-zip; fi;
-
-RUN update-alternatives --set php /usr/bin/php7.4
+    php${php_version}-cli \
+    #php${php_version}-fpm \
+    php${php_version}-mysql \
+    php${php_version}-xml \
+    php${php_version}-mbstring \
+    #php${php_version}-json \
+    php${php_version}-intl \
+    php${php_version}-curl \
+    #php${php_version}-pear \
+    php${php_version}-gd \
+    #php${php_version}-imagick \
+  ; \
+  if [ 7.4 = $php_version ]; then apt-get -qq install -y php${php_version}-json; fi; \
+  if [ "commerce" = "$flavor" ]; then apt-get -qq install -y php${php_version}-zip; fi; \
+  update-alternatives --set php /usr/bin/php${php_version}
 
 # Composer 2
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -16,6 +16,8 @@ LABEL description="Ibexa DXP 4.x"
 ARG flavor=experience
 ARG version=^4.1
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # https://doc.ibexa.co/en/4.0/getting_started/requirements/#php
 # PHP PPA Repository for PHP 7.4
 RUN apt-get -qq update \

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -12,6 +12,7 @@ LABEL description="Ibexa DXP 4.0"
 #ARG installation-key
 #ARG token-password
 ARG flavor=experience
+ARG version=^4.0
 
 # https://doc.ibexa.co/en/4.0/getting_started/requirements/#php
 # PHP PPA Repository for PHP 7.4
@@ -60,7 +61,7 @@ COPY auth.json /root/.composer/auth.json
 RUN mkdir /var/www
 WORKDIR /var/www
 
-RUN composer create-project ibexa/$flavor-skeleton:^4.0 .
+RUN composer create-project ibexa/$flavor-skeleton:$version .
 
 RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
 

--- a/docker/single/Dockerfile-v4
+++ b/docker/single/Dockerfile-v4
@@ -6,7 +6,7 @@ LABEL description="Ibexa DXP 4.x"
 # Usage:
 # docker build . -f docker/single/Dockerfile-v4 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
 # docker build . -f docker/single/Dockerfile-v4 --build-arg flavor=commerce -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
-# docker build . -f docker/single/Dockerfile-v4 --build-arg version=4.0 -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
+# docker build . -f docker/single/Dockerfile-v4 --build-arg version="4.0.*" -t ibexa-dxp:v4 && docker run --name ibexa-dxp-v4 --detach --publish 8004:8080 ibexa-dxp:v4;
 # docker exec -ti ibexa-dxp-v4 bash;
 # docker exec -ti ibexa-dxp-v4 mysql ibexa;
 # docker rm -f ibexa-dxp-v4; docker rmi ibexa-dxp:v4;
@@ -77,7 +77,7 @@ COPY auth.json /root/.composer/auth.json
 RUN mkdir /var/www
 WORKDIR /var/www
 
-RUN composer create-project ibexa/$flavor-skeleton:$version . --no-scripts
+RUN source /root/.bashrc && composer create-project ibexa/$flavor-skeleton:$version .
 
 RUN echo "DATABASE_URL=mysql://root@localhost:3306/ibexa" > .env.local
 


### PR DESCRIPTION
Run Ibexa DXP 4.1, 4.0, 3.3 or eZ Platform 2.5 in a single container with less installation as possible.

TODO:
- [ ] Maybe mount some volume to access project from outside
- [ ] Pass credentials as `ARG` instead of `COPY auth.json`
- [ ] Adjust DATABASE_VERSION in, at least, .env